### PR TITLE
Fixes to support bro packaging/testing

### DIFF
--- a/bro-pkg.meta
+++ b/bro-pkg.meta
@@ -5,4 +5,4 @@ script_dir = scripts
 tags = bro plugin, scan detection
 depends =
   bro >=2.5.1
-  bro/ncsa/bro-is-darknet
+  bro/ncsa/bro-is-darknet *

--- a/testing/btest.cfg
+++ b/testing/btest.cfg
@@ -7,7 +7,6 @@ IgnoreFiles = *.tmp *.swp #* *.trace .DS_Store
 
 [environment]
 BROBASE=`bro-config --bro_dist`
-BROPATH=`bro-config --bropath`
 #BRO_PLUGIN_PATH=`%(testbase)s/Scripts/get-bro-env bro_plugin_path`
 BRO_SEED_FILE=`bro-config --bro_dist`/testing/btest/random.seed
 TZ=UTC


### PR DESCRIPTION
These are in response to bro-pkg issue at: https://github.com/bro/package-manager/issues/13

See the full commit message for reason behind removing BROPATH from the btest.cfg

For the format of the 'depends' metadata field, see http://bro-package-manager.readthedocs.io/en/stable/package.html#depends.  Basically, every dependency needs to be named along with a version requirement and the later was missing here (but bro-pkg was failing to emit an error and silently proceeding).