### PR TITLE
resolve double loading of bro-is-darknet

### DIFF
--- a/scripts/scan.bro
+++ b/scripts/scan.bro
@@ -7,7 +7,9 @@
 
 @load base/utils/time
 
+@ifndef(Site::darknet_mode)
 @load packages/bro-is-darknet
+@endif
 
 module Scan;
 


### PR DESCRIPTION
This should resolve the issue with the logger crashing when bro-is-darknet is installed and loaded.