### PR TITLE
Fix warnings with Zeek 5.0

### DIFF
--- a/scripts/scan.zeek
+++ b/scripts/scan.zeek
@@ -118,6 +118,7 @@ function adjust_known_scanner_expiration(s: table[addr] of interval, idx: addr):
     return duration;
 }
 
+@if ( !Cluster::is_enabled() || Cluster::local_node_type() != Cluster::WORKER )
 function analyze_unique_hostports(attempts: set[Attempt]): Notice::Info
 {
     local ports: set[port];
@@ -248,6 +249,7 @@ function add_scan_attempt(scanner: addr, attempt: Attempt)
         known_scanners[scanner] = 1hrs;
         }
     }
+@endif
 
 @if ( Cluster::is_enabled() )
 ######################################


### PR DESCRIPTION
Zeek 5.0 warns that the following non-exported functions do no have any
callers: add_scan_attempt, analyze_unique_ports, generate_notice. These
are now wrapped in a cluster conditional to prevent the warnings.