### PR TITLE
Fix failing btest with Zeek 6

### DIFF
--- a/testing/tests/test_port_scan.zeek
+++ b/testing/tests/test_port_scan.zeek
@@ -1,6 +1,9 @@
 # @TEST-EXEC: zeek -C -r $TRACES/port_scan.pcap ../../../scripts %INPUT
 # @TEST-EXEC: zeek-cut src p note msg sub < notice.log > notice.tmp && mv notice.tmp notice.log
 # @TEST-EXEC: btest-diff notice.log
+@ifdef ( Site::private_address_space_is_local )
+redef Site::private_address_space_is_local = F;
+@endif
 redef Notice::ignored_types += {Site::New_Used_Address_Space};
 redef Scan::scan_threshold=5;
 redef Site::local_nets = {


### PR DESCRIPTION
With Zeek 6, private subnets are added to Site::local_nets by default. The failing test requires that not to be the case, so for Zeek 6 only, set Site::private_address_space_is_local to F.