### PR TITLE
Map Port_Scan victim to destination

### DIFF
--- a/scripts/scan.zeek
+++ b/scripts/scan.zeek
@@ -148,7 +148,7 @@ function analyze_unique_hostports(attempts: set[Attempt]): Notice::Info
         {
         #Extract the single victim
         for (v in victims)
-            return [$note=Port_Scan, $msg=fmt("%s unique ports on host %s", |ports|, v)];
+            return [$note=Port_Scan, $msg=fmt("%s unique ports on host %s", |ports|, v), $dst=v];
         }
     if(|ports| <= 5)
         {


### PR DESCRIPTION
For "Port_Scan", where we have a fixed singular "victim", map this value back to the destination.

Example.
192.168.0.1 scanned at least 250 unique ports on host 192.168.0.2 in 0m5s

notice.src already correctly maps "scanner", 192.168.0.1 in this example this would add notice.dst mapping to "victim", 192.168.0.2 in this example.

This would replicate the existing and similar behavior for "Address_Scan", where the fixed singular port value is mapped back to port.

Example.
192.168.0.1 scanned at least 250 unique hosts on port 1234/tcp in 0m5s

notice.src already correctly maps "scanner", 192.168.0.1 in this example notice.p already correctly maps "ports", 1234 in this example

Each of these are a 1:1 relationship, allbeit it for different properties. "Random_Scan" is many:many, so would not benefit from any changes.